### PR TITLE
Connect RegisterRouter to TL bus.

### DIFF
--- a/craft/lpddr4_ctrl/src/omc.scala
+++ b/craft/lpddr4_ctrl/src/omc.scala
@@ -88,6 +88,12 @@ object NomcTop {
     val omc = NomcTopBase.attach(c)(bap)
 
     // User code here
+    implicit val p = bap.p
+    bap.pbus.coupleTo("device_named_omc") { bus =>
+      omc.regmap.controlXing(NoCrossing) :=
+        TLWidthWidget(bap.pbus) :=
+        bus
+    }
 
     omc
   }


### PR DESCRIPTION
Hi @Ryan-Sangdeok-Park, I think I have a fix for the first issue that you described in https://sifive.atlassian.net/browse/EAD-329.

I worked on this partially so that I could get a better understanding of Diplomacy and how things are connected. Let me attempt to explain the issue and the fix, and perhaps @hcook can correct me if I'm doing anything wrong here.

For context, for this piece of the LPDDR4 IP from Samsung, the onboarding team decided to instantiate an actual Chisel/Diplomacy RegisterRouter so that they can place it in front of some of the control signals of the block and allow software to control them.

The issue that @Ryan-Sangdeok-Park ran into was:

```
Exception in thread "main" java.lang.IllegalArgumentException: requirement failed: Diplomacy error: regmap.controlNode (A sink node with parent 'regmap/omc_top/dut/top' at  (omc.scala:59:26)) has 1 != 0 up/down inner parameters
```

After crawling through the Diplomacy code, I believe this error message means that the RegisterRouter wasn't actually connected to anything on the TileLink side, meaning that it was not actually connected to the peripheral bus.

To fix this, we need to explicitly attach the RegisterRouter to the `pbus` in the `attach()` method of the outer `omc` block. This part I am less sure about, and I mostly looked at the sifive/blocks UART for inspiration: https://github.com/sifive/sifive-blocks/blob/12bdbe50636b6c57c8dc997e483787fdb5ee540b/src/main/scala/devices/uart/UART.scala#L185-L190

I had to place down a `TLWidthWidget` to convert between the 64-byte wide interface of the RegisterRouter itself to the pbus, which I believe is 8 bytes.